### PR TITLE
Use ping option as the timeout value for websocket connections

### DIFF
--- a/src/engines/proxy.js
+++ b/src/engines/proxy.js
@@ -21,6 +21,7 @@ var Proxy = assign(Class({ className: 'Engine.Proxy',
     this._connections = {};
     this.interval     = this._options.interval || this.INTERVAL;
     this.timeout      = this._options.timeout  || this.TIMEOUT;
+    this.ping        = this._options.ping  || this.timeout;
 
     var engineClass = this._options.type || Memory;
     this._engine    = engineClass.create(this, this._options);

--- a/src/protocol/server.js
+++ b/src/protocol/server.js
@@ -19,6 +19,7 @@ var Server = Class({ className: 'Server',
     this._options  = options || {};
     var engineOpts = this._options.engine || {};
     engineOpts.timeout = this._options.timeout;
+    engineOpts.ping = this._options.ping;
     this._engine   = Engine.get(engineOpts);
 
     this.info('Created new server: ?', this._options);
@@ -145,6 +146,9 @@ var Server = Class({ className: 'Server',
     if (connectionType === 'eventsource') {
       interval = Math.floor(this._engine.timeout * 1000);
       timeout  = 0;
+    } else if (connectionType === 'websocket') {
+      interval = Math.floor(this._engine.interval * 1000);
+      timeout  = Math.floor(this._engine.ping * 1000);
     } else {
       interval = Math.floor(this._engine.interval * 1000);
       timeout  = Math.floor(this._engine.timeout * 1000);


### PR DESCRIPTION
The `ping` is meant to specify how often to send a keep alive ping
to active websockets, to avoid idle connections being automatically
killed by services like Heroku. This may or may not actually be
working, I haven't figured that part out. However, there seems to be
some other kind of ping going on, where every N seconds (N being the
configured `timeout` interval for your Faye server), the server sends
a `/meta/connect` frame to the client, which acknowledges it with a
frame of its own.

If you initialize your faye server with different `ping` and `timeout`
values, the `timeout` value is used for that `/meta/connect` polling,
which is undesirable when attempting to minimize the number of pings
and maximize battery life.

This change makes it so that the `/meta/connect` poll happens every
`ping` seconds for websocket connections, and every `timeout` seconds
for any other transport type. If the `ping` is unset, the `timeout`
is used in all cases.