### PR TITLE
Fix CORS headers handling

### DIFF
--- a/src/adapters/node_adapter.js
+++ b/src/adapters/node_adapter.js
@@ -118,7 +118,7 @@ var NodeAdapter = Class({ className: 'NodeAdapter',
 
     // http://groups.google.com/group/faye-users/browse_thread/thread/4a01bb7d25d3636a
     if (requestMethod === 'OPTIONS' || request.headers['access-control-request-method'] === 'POST')
-      return this._handleOptions(response);
+      return this._handleOptions(request, response);
 
     if (EventSource.isEventSource(request))
       return this.handleEventSource(request, response);
@@ -236,12 +236,13 @@ var NodeAdapter = Class({ className: 'NodeAdapter',
     };
   },
 
-  _handleOptions: function(response) {
+  _handleOptions: function(request, response) {
+    var origin = request.headers.origin || request.headers.referer;
     var headers = {
       'Access-Control-Allow-Credentials': 'true',
       'Access-Control-Allow-Headers':     'Accept, Authorization, Content-Type, Pragma, X-Requested-With',
       'Access-Control-Allow-Methods':     'POST, GET',
-      'Access-Control-Allow-Origin':      '*',
+      'Access-Control-Allow-Origin':      origin || '*',
       'Access-Control-Max-Age':           '86400'
     };
 

--- a/src/transport/cors.js
+++ b/src/transport/cors.js
@@ -76,17 +76,7 @@ var CORS = assign(Class(Transport, {
 
     if (global.XMLHttpRequest) {
       var xhr = new XMLHttpRequest();
-
-      if (xhr.withCredentials !== undefined) {
-        xhr.open('POST', endpoint.href, true);
-        xhr.onload = function (e) {
-          callback.call(context, true);
-        };
-        xhr.onerror = function (e) {
-          callback.call(context, false);
-        };
-        xhr.send(null);
-      }
+      return callback.call(context, xhr.withCredentials !== undefined);
     } else {
       return callback.call(context, false);
     }


### PR DESCRIPTION
- Remove test request bing made in the cors transport isUsable. Faye was
returning 400 because it's sending an empty body
- Have Faye echo the referrer or origin header in CORS headers for options requests